### PR TITLE
Pack breakers CSV schema

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -6938,6 +6938,42 @@ components:
                   Use $ (end-of-string anchor) to prevent extraction.
                 default: /[\\n\\r]+(?!\\s)/
                 example: /\n(?=\S)/
+              delimiterRegex:
+                type: string
+                title: Delimiter regex
+                description: Regex used to split header fields when type is "header".
+                default: "/\\t/"
+                example: "/\\t/"
+              fieldsLineRegex:
+                type: string
+                title: Fields line regex
+                description: Regex that identifies and captures the fields line when type is "header".
+                default: "/^#[Ff]ields[:]?\\s+(.*)/"
+                example: "/^#[Ff]ields[:]?\\s+(.*)/"
+              headerLineRegex:
+                type: string
+                title: Header line regex
+                description: Regex used to identify header lines when type is "header".
+                default: "/^#/"
+                example: "/^#/"
+              delimiter:
+                type: string
+                title: Delimiter
+                description: Field delimiter used for CSV parsing when type is "csv".
+                default: ","
+                example: ","
+              quoteChar:
+                type: string
+                title: Quote character
+                description: Quote character used for CSV parsing when type is "csv".
+                default: "\""
+                example: "\""
+              escapeChar:
+                type: string
+                title: Escape character
+                description: Escape character used for CSV parsing when type is "csv".
+                default: "\\"
+                example: "\\"
               timestamp:
                 type: object
                 required:


### PR DESCRIPTION
Add titles, descriptions, examples, and defaults for CSV and header-specific breaker rule fields in `EventBreakerRuleset`.

This resolves API validation errors when using `csv` or `header` rule types by ensuring the provider's schema aligns with the API's expected fields and improves usability by providing clear documentation and sensible defaults.

---
<a href="https://cursor.com/background-agent?bcId=bc-32fa1b8f-7e41-461b-8e6e-43ad17aa2998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-32fa1b8f-7e41-461b-8e6e-43ad17aa2998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

