### PR TITLE
Criblio output marshal error

### DIFF
--- a/internal/provider/destination_resource_sdk.go
+++ b/internal/provider/destination_resource_sdk.go
@@ -20293,5 +20293,20 @@ func (r *DestinationResourceModel) ToSharedOutput(ctx context.Context) (*shared.
 		}
 	}
 
+	if r.OutputGrafanaCloud != nil && outputGrafanaCloud == nil {
+		diags.AddError(
+			"Grafana Cloud output requires a variant",
+			"Set output_grafana_cloud.output_grafana_cloud_grafana_cloud1 or output_grafana_cloud.output_grafana_cloud_grafana_cloud2.",
+		)
+		return nil, diags
+	}
+	if out == (shared.Output{}) {
+		diags.AddError(
+			"Missing output configuration",
+			"Set exactly one of the output_* attributes on the destination (for example output_grafana_cloud.output_grafana_cloud_grafana_cloud2).",
+		)
+		return nil, diags
+	}
+
 	return &out, diags
 }

--- a/internal/provider/packdestination_resource_sdk.go
+++ b/internal/provider/packdestination_resource_sdk.go
@@ -20272,5 +20272,20 @@ func (r *PackDestinationResourceModel) ToSharedOutput(ctx context.Context) (*sha
 		}
 	}
 
+	if r.OutputGrafanaCloud != nil && outputGrafanaCloud == nil {
+		diags.AddError(
+			"Grafana Cloud output requires a variant",
+			"Set output_grafana_cloud.output_grafana_cloud_grafana_cloud1 or output_grafana_cloud.output_grafana_cloud_grafana_cloud2.",
+		)
+		return nil, diags
+	}
+	if out == (shared.Output{}) {
+		diags.AddError(
+			"Missing output configuration",
+			"Set exactly one of the output_* attributes on the destination (for example output_grafana_cloud.output_grafana_cloud_grafana_cloud2).",
+		)
+		return nil, diags
+	}
+
 	return &out, diags
 }


### PR DESCRIPTION
Add provider-side validation for `shared.Output` union types to prevent generic JSON marshalling errors.

The `shared.Output` type is a union, and if none of its variants are correctly configured (e.g., for Grafana Cloud, if `output_grafana_cloud` is set but no nested variant like `output_grafana_cloud_grafana_cloud1` is provided), the Terraform apply would fail with a cryptic "error serializing request body: json: error calling MarshalJSON for type shared.Output: could not marshal union type Output: all fields are null". This change introduces specific validation to catch these misconfigurations early and provide actionable error messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-b64f2221-c363-4604-aed7-4c85bef2aa07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b64f2221-c363-4604-aed7-4c85bef2aa07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

