### PR TITLE
OpenAPI anyOf removal

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -13351,11 +13351,6 @@ components:
           title: Description
           example: Grafana listener supporting Prom remote write and Loki logs
       type: object
-      anyOf:
-        - required:
-            - prometheusAPI
-        - required:
-            - lokiAPI
     InputLoki:
       required:
         - host
@@ -26180,13 +26175,6 @@ components:
             handshake. Disable if compatibility issues arise.
           example: true
       type: object
-      anyOf:
-        - required:
-            - host
-            - udpPort
-        - required:
-            - host
-            - tcpPort
     InputFile:
       required:
         - id
@@ -46767,11 +46755,6 @@ components:
           title: ""
           example: {}
       type: object
-      anyOf:
-        - required:
-            - lokiUrl
-        - required:
-            - prometheusUrl
     OutputLoki:
       required:
         - url


### PR DESCRIPTION
Remove `anyOf` schemas from `openapi.yml` to resolve Speakeasy generation failures in `packsource_resource.go`.

The `anyOf` keyword in OpenAPI is not fully supported by Speakeasy, leading to incomplete model generation and subsequent "undefined" method errors in the generated Go code for the `PackSourceResourceModel`. Removing these constructs allows Speakeasy to generate valid code.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c7fd4df-ae9c-4188-b99c-952dbe87ae4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c7fd4df-ae9c-4188-b99c-952dbe87ae4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

