### PR TITLE
Grafana cloud output openapi

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -46767,11 +46767,6 @@ components:
           title: ""
           example: {}
       type: object
-      anyOf:
-        - required:
-            - lokiUrl
-        - required:
-            - prometheusUrl
     OutputLoki:
       required:
         - url


### PR DESCRIPTION
Remove `anyOf` constraint from `OutputGrafanaCloud` in `openapi.yml` to fix serialization error.

The `anyOf` constraint was generating a Terraform union type, which prevented the `output_grafana_cloud` block from correctly populating the `shared.Output` object, leading to the `all fields are null` serialization error. Removing it allows the provider to correctly interpret the resource configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-c34831a3-727b-4d95-a371-d2cd03c040ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c34831a3-727b-4d95-a371-d2cd03c040ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

