### PR TITLE
Pack pipeline metrics definition

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -54678,6 +54678,14 @@ components:
           description: JSON schema matching standards of draft version 2019-09
           example: '{"type":"object","properties":{"_raw":{"type":"string"}}}'
     PipelineFunctionConf:
+      oneOf:
+        - $ref: "#/components/schemas/PipelineFunctionPublishMetrics"
+        - $ref: "#/components/schemas/PipelineFunctionConfGeneric"
+      discriminator:
+        propertyName: id
+        mapping:
+          publish_metrics: "#/components/schemas/PipelineFunctionPublishMetrics"
+    PipelineFunctionConfGeneric:
       type: object
       required:
         - id
@@ -54719,6 +54727,112 @@ components:
             addFields:
               app: orders
               env: prod
+        groupId:
+          title: Group ID
+          description: Group ID
+          type: string
+          example: default
+    FunctionConfSchemaPublishMetrics:
+      type: object
+      title: ""
+      additionalProperties: false
+      properties:
+        fields:
+          title: Add metrics
+          description: List of metrics from event to extract and format. Formatted metrics can be used by a destination to pass metrics to a metrics aggregation platform.
+          type: array
+          minItems: 0
+          items:
+            type: object
+            required:
+              - inFieldName
+              - metricType
+            properties:
+              inFieldName:
+                type: string
+                title: Event Field Name
+                description: The name of the field in the event that contains the metric value
+              outFieldExpr:
+                type: string
+                title: Metric Name Expression
+                description: JavaScript expression to evaluate the metric field name. Defaults to Event Field Name.
+              metricType:
+                type: string
+                title: Metric Type
+                enum:
+                  - counter
+                  - timer
+                  - gauge
+                  - distribution
+                  - summary
+                  - histogram
+                x-speakeasy-enum-descriptions:
+                  - Counter
+                  - Timer
+                  - Gauge
+                  - Distribution
+                  - Summary
+                  - Histogram
+                x-speakeasy-unknown-values: allow
+        overwrite:
+          type: boolean
+          title: Overwrite
+          description: Overwrite previous metric specs. Leave disabled to append.
+        dimensions:
+          type: array
+          title: Add dimensions
+          description: Optional list of dimensions to include in events. Wildcards supported. If you don't specify metrics, values will be appended to every metric found in the event. When you add a new metric, dimensions will be present only in those new metrics.
+          items:
+            type: string
+        removeMetrics:
+          title: Remove metrics
+          description: Optional list of metric field names to look for when removing metrics. When a metric's field name matches an element in this list, the metric will be removed from the event.
+          type: array
+          items:
+            type: string
+        removeDimensions:
+          type: array
+          title: Remove dimensions
+          description: Optional list of dimensions to remove from every metric found in the event. Wildcards supported.
+          items:
+            type: string
+    PipelineFunctionPublishMetrics:
+      type: object
+      required:
+        - id
+        - conf
+      additionalProperties: false
+      properties:
+        filter:
+          title: Filter
+          description: Filter that selects data to be fed through this Function
+          type: string
+          default: "true"
+          example: '_source == "app"'
+        id:
+          title: ID
+          description: Function ID
+          type: string
+          enum:
+            - publish_metrics
+        description:
+          title: Description
+          description: Simple description of this step
+          type: string
+          example: Parse and enrich fields
+        disabled:
+          title: Disabled
+          description: If true, data will not be pushed through this function
+          type: boolean
+          example: false
+        final:
+          title: Final
+          description: If enabled, stops the results of this Function from being passed to
+            the downstream Functions
+          type: boolean
+          example: false
+        conf:
+          $ref: "#/components/schemas/FunctionConfSchemaPublishMetrics"
         groupId:
           title: Group ID
           description: Group ID


### PR DESCRIPTION
Add `publish_metrics` specific schemas and discriminator to `openapi.yml` to correctly map Terraform fields to API camelCase.

The previous schema did not correctly map the snake_case field names (e.g., `in_field_name`, `out_field_expr`, `metric_type`, `remove_dimensions`) from the Terraform provider to the camelCase names expected by the API for the `publish_metrics` function, leading to "Cannot read properties of undefined (reading 'name')" errors. This change introduces a dedicated schema for `publish_metrics` and uses a discriminator to ensure proper serialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-4829ae0d-928b-4c1d-ba74-bffc54181841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4829ae0d-928b-4c1d-ba74-bffc54181841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

