### PR TITLE
E2e pack pipeline 404

### DIFF
--- a/tests/e2e/scripts/import.sh
+++ b/tests/e2e/scripts/import.sh
@@ -62,5 +62,5 @@ terraform import -no-color criblio_pack_destination.my_packdest '{"group_id": "d
 echo
 terraform import -no-color criblio_pack_routes.my_packroutes '{"group_id": "default", "pack": "pack-with-routes"}' 
 echo
-terraform import -no-color criblio_pack_pipeline.my_packpipeline '{"group_id": "default", "pack": "pack-with-pipeline"}'
+terraform import -no-color criblio_pack_pipeline.my_packpipeline '{"group_id": "default", "pack": "pack-with-pipeline", "id": "my_id"}'
 echo


### PR DESCRIPTION
Add missing `id` field to `criblio_pack_pipeline` import script to fix 404 errors during e2e tests.

The e2e import script was missing the required `id` field for `criblio_pack_pipeline`. The import ID must be a JSON object with `group_id`, `id`, and `pack` as per the resource’s `ImportState` logic. Without the `id`, the import would fail, leading to subsequent 404 errors during Terraform refresh operations.

---
<p><a href="https://cursor.com/agents/bc-155cdea4-f602-41f7-9eb2-9f78bbda3160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-155cdea4-f602-41f7-9eb2-9f78bbda3160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

